### PR TITLE
Add option to disable Consul service discovery

### DIFF
--- a/lib/requestService.js
+++ b/lib/requestService.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const http = require('http');
+
+const getenv = require('getenv');
 const log = require('seal-log').getLogger();
 const retry = require('retry');
 
@@ -7,7 +10,7 @@ const connectService = require('seal-connect-service');
 
 const resolve = require('./resolve');
 
-const requestService = function (options, callback) {
+const requestServiceConsul = function (options, callback) {
   if (!options) {
     throw new Error('Options are missing.');
   }
@@ -52,6 +55,33 @@ const requestService = function (options, callback) {
       });
     });
   });
+};
+
+const requestService = function (options, callback) {
+  if (!options) {
+    throw new Error('Options are missing.');
+  }
+  if (!options.service) {
+    throw new Error('Service name is missing.');
+  }
+  if (!callback) {
+    throw new Error('Callback is missing.');
+  }
+
+  const serviceDiscovery = getenv('SERVICE_DISCOVERY', 'consul');
+  const servicePort = getenv.int('SERVICE_DISCOVERY_PORT', 3000);
+
+  if (serviceDiscovery === 'consul') {
+    return requestServiceConsul(options, callback);
+  }
+
+  if (options.protocol === 'http') {
+    options.protocol = 'http:';
+  }
+  options.port = servicePort;
+  options.hostname = options.service;
+
+  http.request(options, callback);
 };
 
 module.exports = requestService;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "assertthat": "0.10.3",
     "eslint-config-seal": "0.0.9",
+    "nodeenv": "1.0.0",
     "proxyquire": "1.8.0",
     "roboter": "0.15.3",
     "roboter-server": "0.15.3"


### PR DESCRIPTION
For cloud environments, disable the Consul service discovery by setting env `SERVICE_DISCOVERY=cloud`.
The other service's port is assumed at port 3000, can be adjusted with env `SERVICE_DISCOVERY_PORT=3000`.

